### PR TITLE
On Windows, use twapi::tls_socket as alternative to tls::socket.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Required Packages
 -----------------
 * uri - from Tcllib
 * gc_class - https://github.com/RubyLane/gc_class
-* tls - for HTTPS support (optional)
+* tls or twapi - for HTTPS support (optional)
 * sockopt - https://github.com/cyanogilvie/sockopt (optional)
 
 License


### PR DESCRIPTION
Added support for using twapi::tls_socket on Windows as an alternative to tls::socket. Primary reason is that trusted root certificates are not kept up to date for tls::socket.